### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 # EDUCHAIN Agent Kit
 
 ![SailfishAgent](https://github.com/user-attachments/assets/32a0f51a-fb86-4841-b120-b581d9db6fbf)
-</div>
+
+<a href="https://glama.ai/mcp/servers/fd54q7e2lz">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/fd54q7e2lz/badge" alt="EDUCHAIN Agent Kit MCP server" />
+</a>
 
 This MCP (Model Context Protocol) server provides tools and resources for interacting with EDUCHAIN. It allows Claude to query information about tokens and pools and perform swaps through SailFish DEX.
 


### PR DESCRIPTION
This PR adds a badge for the [EDUCHAIN Agent Kit](https://glama.ai/mcp/servers/fd54q7e2lz) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/fd54q7e2lz">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/fd54q7e2lz/badge" alt="EDUCHAIN Agent Kit MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.